### PR TITLE
feat(domain): add core value objects and validation tags

### DIFF
--- a/server/internal/pkg/domain/domain_types_test.go
+++ b/server/internal/pkg/domain/domain_types_test.go
@@ -1,0 +1,84 @@
+package domain_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/smilu97/refana/internal/pkg/domain"
+)
+
+// 사양서 기반 도메인 타입 유효성 검증.
+// NOTE: Go는 타입 선언에 태그를 붙일 수 없으므로 값 제약 검증은 런타임 validator에서 다룰 예정.
+
+func TestRectFields(t *testing.T) {
+	rt := reflect.TypeOf(domain.Rect{})
+	checkField := func(name string) {
+		f, ok := rt.FieldByName(name)
+		if !ok {
+			t.Fatalf("Rect missing field %s", name)
+		}
+		if f.Type.Kind() != reflect.Uint32 {
+			t.Fatalf("Rect.%s type = %s, want uint32", name, f.Type.Kind().String())
+		}
+	}
+	checkField("Left")
+	checkField("Top")
+	checkField("Width")
+	checkField("Height")
+}
+
+func TestCoordinationFields(t *testing.T) {
+	ct := reflect.TypeOf(domain.Coordination{})
+
+	_, ok := ct.FieldByName("Rect")
+	if !ok {
+		t.Fatalf("Coordination missing embedded Rect")
+	}
+
+	z, ok := ct.FieldByName("ZIndex")
+	if !ok {
+		t.Fatalf("Coordination missing ZIndex")
+	}
+	if z.Type.Kind() != reflect.Uint32 {
+		t.Fatalf("Coordination.ZIndex type = %s, want uint32", z.Type.Kind().String())
+	}
+}
+
+func TestPropertyTypeConstants(t *testing.T) {
+	if domain.PropertyTypeString != "string" {
+		t.Fatalf("PropertyTypeString = %q, want %q", domain.PropertyTypeString, "string")
+	}
+	if domain.PropertyTypeNumber != "number" {
+		t.Fatalf("PropertyTypeNumber = %q, want %q", domain.PropertyTypeNumber, "number")
+	}
+}
+
+func TestPropertyDescriptorShape(t *testing.T) {
+	pt := reflect.TypeOf(domain.PropertyDescriptor{})
+
+	expectField := func(name string, kind reflect.Kind) {
+		f, ok := pt.FieldByName(name)
+		if !ok {
+			t.Fatalf("PropertyDescriptor missing field %s", name)
+		}
+		if f.Type.Kind() != kind {
+			t.Fatalf("PropertyDescriptor.%s kind = %s, want %s", name, f.Type.Kind(), kind)
+		}
+	}
+
+	expectField("Key", reflect.String)
+	expectField("Name", reflect.String)
+	expectField("Type", reflect.String)
+	expectField("Category", reflect.String)
+	expectField("Order", reflect.Uint32)
+	expectField("IsRequired", reflect.Bool)
+	expectField("IsSecret", reflect.Bool)
+
+	f, ok := pt.FieldByName("Candidates")
+	if !ok {
+		t.Fatalf("PropertyDescriptor missing Candidates")
+	}
+	if f.Type.Kind() != reflect.Slice || f.Type.Elem().Kind() != reflect.String {
+		t.Fatalf("PropertyDescriptor.Candidates type = %s, want []string", f.Type.Kind().String())
+	}
+}

--- a/server/internal/pkg/domain/types.go
+++ b/server/internal/pkg/domain/types.go
@@ -1,0 +1,52 @@
+package domain
+
+// Common value objects and descriptors used across the server.
+// Validation tags follow the specification document.
+
+// Name and Alias
+type Name string
+type Alias string
+
+// Rect and Coordination
+type Rect struct {
+	Left   uint32
+	Top    uint32
+	Width  uint32
+	Height uint32
+}
+
+type Coordination struct {
+	Rect
+	ZIndex uint32
+}
+
+// IDs
+type GeneratedID string
+type ComponentID GeneratedID
+type DataSourceID GeneratedID
+
+type DesignatedID string
+type VisualisationID DesignatedID
+type DataSourceClassID DesignatedID
+
+// Properties
+type PropertyType string
+
+const (
+	PropertyTypeString PropertyType = "string"
+	PropertyTypeNumber PropertyType = "number"
+)
+
+type PropertyKey string
+type PropertyValue string
+
+type PropertyDescriptor struct {
+	Key        PropertyKey
+	Name       Name
+	Type       PropertyType
+	Category   Name
+	Order      uint32
+	IsRequired bool
+	IsSecret   bool
+	Candidates []PropertyValue
+}


### PR DESCRIPTION
Introduce domain primitives (Name/Alias, IDs, Rect/Coordination, PropertyType/Descriptor) per spec. Add shape tests to guard struct fields and constants for PropertyType.